### PR TITLE
chore: fix typos

### DIFF
--- a/src/AttestationIndexer.sol
+++ b/src/AttestationIndexer.sol
@@ -60,7 +60,7 @@ contract AttestationIndexer is UUPSUpgradeable, AccessControlUpgradeable, Pausab
     }
 
     /**
-     * @notice Pause the contract, halting index the attestation.
+     * @notice Pause the contract, halting attestation indexing.
      * @dev Only callable by accounts with PAUSER_ROLE
      */
     function pause() external onlyRole(PAUSER_ROLE) {
@@ -68,7 +68,7 @@ contract AttestationIndexer is UUPSUpgradeable, AccessControlUpgradeable, Pausab
     }
 
     /**
-     * @notice Resumes the contract, allowing index the attestation.
+     * @notice Resumes the contract, resuming attestation indexing.
      * @dev Only callable by accounts with PAUSER_ROLE
      */
     function unpause() external onlyRole(PAUSER_ROLE) {

--- a/src/abstract/AddressIndexingResolverUpgradeable.sol
+++ b/src/abstract/AddressIndexingResolverUpgradeable.sol
@@ -9,7 +9,7 @@ import {IndexerUpdated, InvalidIndexer} from "../libraries/Common.sol";
 
 /**
  * @title Address Dojang Indexing Resolver for EAS
- * @dev A base contract for creating an EAS Schema Resolver than indexes attestations
+ * @dev A base contract for creating an EAS Schema Resolver that indexes attestations
  * for address dojang.
  */
 abstract contract AddressIndexingResolverUpgradeable is Initializable, SchemaResolverUpgradeable {

--- a/src/abstract/BalanceIndexingResolverUpgradeable.sol
+++ b/src/abstract/BalanceIndexingResolverUpgradeable.sol
@@ -9,7 +9,7 @@ import {IndexerUpdated, InvalidIndexer} from "../libraries/Common.sol";
 
 /**
  * @title Balance Dojang Indexing Resolver for EAS
- * @dev A base contract for creating an EAS Schema Resolver than indexes attestations
+ * @dev A base contract for creating an EAS Schema Resolver that indexes attestations
  * for balance dojang.
  */
 abstract contract BalanceIndexingResolverUpgradeable is Initializable, SchemaResolverUpgradeable {

--- a/src/abstract/BalanceValidationResolverUpgradeable.sol
+++ b/src/abstract/BalanceValidationResolverUpgradeable.sol
@@ -8,7 +8,7 @@ import {BIP44CoinTypes} from "../libraries/Types.sol";
 
 /**
  * @title Balance Dojang Validation Resolver for EAS
- * @dev A base contract for creating an EAS Schema Resolver than validate attestations
+ * @dev A base contract for creating an EAS Schema Resolver that validate attestations
  * for balance dojang.
  */
 abstract contract BalanceValidationResolverUpgradeable is Initializable, SchemaResolverUpgradeable {

--- a/src/interfaces/IDojangAttester.sol
+++ b/src/interfaces/IDojangAttester.sol
@@ -9,7 +9,7 @@ interface IDojangAttester {
     event AddressRevoked(address indexed addr);
 
     /// @notice Emitted when a balance is attested
-    event BalanceAttested(address indexed recipient, uint256 indexed coinType, uint64 indexed snashotAt);
+    event BalanceAttested(address indexed recipient, uint256 indexed coinType, uint64 indexed snapshotAt);
 
     /// @notice Emitted when a balance is revoked
     event BalanceRevoked(address indexed recipient, uint256 indexed coinType, uint64 indexed snapshotAt);


### PR DESCRIPTION
## Description
This PR fixes some typos found in the codebase.
These changes do not affect functionality but improve readability and consistency.

## Changes
src/interfaces/IDojangAttester.sol
event BalanceAttested(... uint64 indexed snashotAt); → snapshotAt (misspelled parameter name).

src/abstract/
AddressIndexingResolverUpgradeable.sol: “Resolver than indexes attestations” → “Resolver that indexes attestations”
BalanceIndexingResolverUpgradeable.sol: “Resolver than indexes attestations” → “Resolver that indexes attestations”
BalanceValidationResolverUpgradeable.sol: “Resolver than validate attestations” → “Resolver that validates attestations”

src/AttestationIndexer.sol
“halting index the attestation” → “halting attestation indexing”
“allowing index the attestation” → “resuming attestation indexing”

## Related Issue
Closes #1 