### PR TITLE
fix: improve code style and naming conventions

### DIFF
--- a/script/utils/Artifacts.s.sol
+++ b/script/utils/Artifacts.s.sol
@@ -12,14 +12,14 @@ struct Deployment {
 
 abstract contract Artifacts {
     /// @notice Foundry cheatcode VM.
-    Vm private constant _vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    Vm private constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     string internal _deploymentOutFile;
     mapping(string => Deployment) internal _namedDeployments;
 
     function setUp() public virtual {
         _deploymentOutFile =
-            string.concat(_vm.projectRoot(), "/deployments/", _vm.toString(block.chainid), "-deploy.json");
+            string.concat(VM.projectRoot(), "/deployments/", VM.toString(block.chainid), "-deploy.json");
         _ensurePath(_deploymentOutFile);
         console.log("Writing artifact to %s", _deploymentOutFile);
 
@@ -50,15 +50,15 @@ abstract contract Artifacts {
     }
 
     function _ensurePath(string memory path) private {
-        string[] memory outputs = _vm.split(path, "/");
+        string[] memory outputs = VM.split(path, "/");
         string memory dir = "";
         for (uint256 i = 0; i < outputs.length - 1; i++) {
             dir = string.concat(dir, outputs[i], "/");
         }
-        _vm.createDir(dir, true);
+        VM.createDir(dir, true);
     }
 
     function _appendDeployment(Deployment memory deployment) internal {
-        _vm.writeJson({json: stdJson.serialize("", deployment.name, deployment.addr), path: _deploymentOutFile});
+        VM.writeJson({json: stdJson.serialize("", deployment.name, deployment.addr), path: _deploymentOutFile});
     }
 }

--- a/src/AttestationIndexer.sol
+++ b/src/AttestationIndexer.sol
@@ -34,7 +34,7 @@ contract AttestationIndexer is UUPSUpgradeable, AccessControlUpgradeable, Pausab
     mapping(
         bytes32 schemaUid
             => mapping(address attester => mapping(address recipient => mapping(bytes32 key => bytes32 attestationUid)))
-    ) private _rawDB;
+    ) private rawDB;
 
     /**
      * @dev Locks the contract, preventing any future reinitialization. This
@@ -87,7 +87,7 @@ contract AttestationIndexer is UUPSUpgradeable, AccessControlUpgradeable, Pausab
         view
         returns (bytes32)
     {
-        return _rawDB[schemaUid][attester][recipient][DEFAULT_KEY];
+        return rawDB[schemaUid][attester][recipient][DEFAULT_KEY];
     }
 
     /**
@@ -103,7 +103,7 @@ contract AttestationIndexer is UUPSUpgradeable, AccessControlUpgradeable, Pausab
         view
         returns (bytes32)
     {
-        return _rawDB[schemaUid][attester][recipient][key];
+        return rawDB[schemaUid][attester][recipient][key];
     }
 
     /**
@@ -139,7 +139,7 @@ contract AttestationIndexer is UUPSUpgradeable, AccessControlUpgradeable, Pausab
         Attestation memory attestation = _EAS.getAttestation(attestationUid);
         attestation.verify();
 
-        _rawDB[attestation.schema][attestation.attester][attestation.recipient][key] = attestationUid;
+        rawDB[attestation.schema][attestation.attester][attestation.recipient][key] = attestationUid;
         emit AttestationIndexed(attestation.schema, attestation.attester, attestation.recipient, key, attestation.uid);
     }
 }


### PR DESCRIPTION
- Fix variable naming convention: _rawDB  rawDB in AttestationIndexer.sol
- Fix constant naming convention: _vm  VM in Artifacts.s.sol
- Follow Solidity style guide for better code readability
- Update all references to maintain consistency