### PR TITLE
✨ feat(indexer): add key-indexed attest storage

### DIFF
--- a/src/interfaces/IAttestationIndexer.sol
+++ b/src/interfaces/IAttestationIndexer.sol
@@ -69,4 +69,20 @@ interface IAttestationIndexer {
         external
         view
         returns (bytes32);
+
+    /**
+     * @notice Retrieves attestation UIDs indexed by schema, attester, and key
+     * @param schemaUid The UID of the EAS schema
+     * @param attester The attester address of the attestation
+     * @param key The key under which the attestations were indexed
+     * @return attestationUids An array of UIDs of the indexed attestations
+     */
+    function getAttestationUids(
+        bytes32 schemaUid,
+        address attester,
+        bytes32 key
+    )
+        external
+        view
+        returns (bytes32[] memory);
 }

--- a/test/AttestationIndexer.t.sol
+++ b/test/AttestationIndexer.t.sol
@@ -166,6 +166,10 @@ contract AttestationIndexer_Test is AttestationIndexer_Base {
         attestationIndexer.index(ATTESTATION_UID);
 
         assertEq(attestationIndexer.getAttestationUid(SCHEMA_UID, attester, RECIPIENT), ATTESTATION_UID);
+        assertEq(
+            attestationIndexer.getAttestationUids(SCHEMA_UID, attester, attestationIndexer.DEFAULT_KEY())[0],
+            ATTESTATION_UID
+        );
     }
 
     function test_index_with_customKey() public {
@@ -184,6 +188,7 @@ contract AttestationIndexer_Test is AttestationIndexer_Base {
         attestationIndexer.index(customKey, ATTESTATION_UID);
 
         assertEq(attestationIndexer.getAttestationUid(SCHEMA_UID, attester, RECIPIENT, customKey), ATTESTATION_UID);
+        assertEq(attestationIndexer.getAttestationUids(SCHEMA_UID, attester, customKey)[0], ATTESTATION_UID);
     }
 
     function test_index_revert_when_attestation_invalid() public {


### PR DESCRIPTION
### Description
Add key→UID list indexing in AttestationIndexer so callers can fetch all attestations for (schemaUid, attester, key) regardless of recipient and select/scan the latest as needed.

### Related Issue
Closes #8 