### PR TITLE
rename npm package scope from @giwa to @giwa-io

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,5 +72,5 @@ jobs:
           pnpm dep
           pnpm build
           pnpm contracts:build
-          pnpm --filter @giwa/dojang-contracts test
+          pnpm --filter @giwa-io/dojang-contracts test
         working-directory: .

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "lint": "forge fmt --check && pnpm solhint \"src/**/*.sol\" --max-warnings=0",
     "lint:fix": "forge fmt && pnpm solhint \"src/**/*.sol\" --fix",
     "slither": "slither .",
-    "contracts:generate": "pnpm --filter @giwa/dojang-contracts generate",
-    "contracts:build": "pnpm --filter @giwa/dojang-contracts build"
+    "contracts:generate": "pnpm --filter @giwa-io/dojang-contracts generate",
+    "contracts:build": "pnpm --filter @giwa-io/dojang-contracts build"
   },
   "devDependencies": {
     "solhint": "^5.0.5"

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,4 +1,4 @@
-# @giwa/dojang-contracts
+# @giwa-io/dojang-contracts
 
 TypeScript ABI and addresses for Dojang contracts on the GIWA chain.
 
@@ -7,16 +7,16 @@ ABIs are exported as `as const` literals, enabling full type inference with [vie
 ## Install
 
 ```bash
-npm install @giwa/dojang-contracts
+npm install @giwa-io/dojang-contracts
 # or
-pnpm add @giwa/dojang-contracts
+pnpm add @giwa-io/dojang-contracts
 ```
 
 ## Usage
 
 ```typescript
 import { createPublicClient, http } from 'viem';
-import { dojangScrollAbi, addresses } from '@giwa/dojang-contracts';
+import { dojangScrollAbi, addresses } from '@giwa-io/dojang-contracts';
 
 const client = createPublicClient({ chain: giwaSepolia, transport: http() });
 
@@ -42,7 +42,7 @@ const verified = await client.readContract({
 Chain-specific contract addresses are exported via `addresses`:
 
 ```typescript
-import { addresses } from '@giwa/dojang-contracts';
+import { addresses } from '@giwa-io/dojang-contracts';
 
 addresses[91342].DojangScroll     // '0xd5077b67dcb56caC8b270C7788FC3E6ee03F17B9'
 addresses[91342].EAS              // '0x4200000000000000000000000000000000000021'

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@giwa/dojang-contracts",
+  "name": "@giwa-io/dojang-contracts",
   "version": "0.5.0",
   "description": "TypeScript ABI and addresses for Dojang contracts",
   "license": "MIT",

--- a/packages/contracts/test/typecheck.ts
+++ b/packages/contracts/test/typecheck.ts
@@ -1,5 +1,5 @@
 /**
- * Type-level verification for @giwa/dojang-contracts
+ * Type-level verification for @giwa-io/dojang-contracts
  *
  * This file does NOT run — it only compiles.
  * `tsc --noEmit` on this file verifies that ABI and address exports


### PR DESCRIPTION
### Description
Rename the npm package scope from `@giwa` to `@giwa-io` to match the actual npm organization name.

### Related Issue
Closes #28