### PR TITLE
♻️ Resolve balance root attestation via refUID in DojangScroll

### DIFF
--- a/src/DojangScroll.sol
+++ b/src/DojangScroll.sol
@@ -147,17 +147,24 @@ contract DojangScroll is UUPSUpgradeable, AccessControlUpgradeable, IDojangScrol
     {
         Attestation memory attestation = _getBalanceAttestation(recipient, coinType, snapshotAt, attesterId);
         attestation.verify();
-        Attestation memory rootAttestation = _getBalanceRootAttestation(coinType, snapshotAt, attesterId);
-        rootAttestation.verify();
+
+        if (attestation.refUID == bytes32(0)) revert NotVerifiedBalance(recipient, coinType, snapshotAt);
+
+        Attestation memory rootAttestation = _EAS.getAttestation(attestation.refUID);
+        bytes32 rootSchemaUid = _schemaBook.getSchemaUid(DojangSchemaIds.BALANCE_ROOT_DOJANG);
+        // Root attestations always use address(0) as recipient
+        rootAttestation.verify(address(0), rootSchemaUid);
+
+        address attesterAddress = _dojangAttesterBook.getAttester(attesterId);
+        if (rootAttestation.attester != attesterAddress) {
+            revert MismatchRootAttester(rootAttestation.attester, attesterAddress);
+        }
 
         (uint256 decodedCoinType, uint64 decodedSnapshotAt,,,) =
             abi.decode(rootAttestation.data, (uint256, uint64, uint192, uint256, bytes32));
         (uint256 decodedBalance,,) = abi.decode(attestation.data, (uint256, bytes32, bytes32[]));
 
-        if (
-            rootAttestation.uid != attestation.refUID || decodedCoinType != coinType || decodedSnapshotAt != snapshotAt
-                || attestation.recipient != recipient
-        ) {
+        if (decodedCoinType != coinType || decodedSnapshotAt != snapshotAt || attestation.recipient != recipient) {
             revert NotVerifiedBalance(recipient, coinType, snapshotAt);
         }
 
@@ -230,9 +237,9 @@ contract DojangScroll is UUPSUpgradeable, AccessControlUpgradeable, IDojangScrol
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 0.5.0
+    /// @custom:semver 0.5.1
     function version() public pure virtual returns (string memory) {
-        return "0.5.0";
+        return "0.5.1";
     }
 
     /**

--- a/src/interfaces/IDojangScroll.sol
+++ b/src/interfaces/IDojangScroll.sol
@@ -25,6 +25,9 @@ interface IDojangScroll {
      */
     error NotVerifiedBalance(address recipient, uint256 coinType, uint64 snapshotAt);
 
+    /// @notice Thrown when the root attestation's attester does not match the expected attester.
+    error MismatchRootAttester(address actual, address expected);
+
     /**
      * @notice Checks whether the given address has a verified attestation from the specified attester
      * @dev Returns true if a verified attestation exists for the address-attester pair

--- a/test/DojangScroll.t.sol
+++ b/test/DojangScroll.t.sol
@@ -80,7 +80,7 @@ contract DojangScroll_Upgrade is DojangScroll_Base {
     }
 
     function test_upgrade_succeeds_by_upgrader() public {
-        assertEq(dojangScroll.version(), "0.5.0");
+        assertEq(dojangScroll.version(), "0.5.1");
 
         address newImpl = address(new DojangScrollV2());
 
@@ -332,6 +332,20 @@ contract DojangScroll_Test is DojangScroll_Base {
         );
     }
 
+    // getVerifiedBalance only: mock the root attestation looked up directly by refUID
+    function mockRootAttestationByRefUID(Attestation memory rootAttestation) internal {
+        vm.mockCall(
+            SCHEMA_BOOK,
+            abi.encodeWithSelector(SchemaBook.getSchemaUid.selector, DojangSchemaIds.BALANCE_ROOT_DOJANG),
+            abi.encode(BALANCE_ROOT_DOJANG_SCHEMA_UID)
+        );
+        vm.mockCall(
+            Predeploys.EAS,
+            abi.encodeWithSelector(IEAS.getAttestation.selector, rootAttestation.uid),
+            abi.encode(rootAttestation)
+        );
+    }
+
     function mockGetBalanceAttestation(Attestation memory attestation) internal {
         vm.mockCall(
             SCHEMA_BOOK,
@@ -541,7 +555,7 @@ contract DojangScroll_Test is DojangScroll_Base {
         balanceRootAttestation.data =
             abi.encode(SOLANA_COIN_TYPE, otherSnapshotTime, uint192(1), uint256(1), bytes32(0));
         mockGetBalanceAttestation(balanceAttestation);
-        mockGetBalanceRootAttestation(balanceRootAttestation);
+        mockRootAttestationByRefUID(balanceRootAttestation);
 
         vm.expectRevert(
             abi.encodeWithSelector(IDojangScroll.NotVerifiedBalance.selector, ADDRESS, SOLANA_COIN_TYPE, SNAPSHOT_AT)
@@ -549,9 +563,42 @@ contract DojangScroll_Test is DojangScroll_Base {
         dojangScroll.getVerifiedBalance(ADDRESS, SOLANA_COIN_TYPE, SNAPSHOT_AT, DojangAttesterIds.UPBIT_KOREA);
     }
 
+    function test_getVerifiedBalance_revert_when_refUidZero() public {
+        balanceAttestation.refUID = bytes32(0);
+        mockGetBalanceAttestation(balanceAttestation);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IDojangScroll.NotVerifiedBalance.selector, ADDRESS, SOLANA_COIN_TYPE, SNAPSHOT_AT)
+        );
+        dojangScroll.getVerifiedBalance(ADDRESS, SOLANA_COIN_TYPE, SNAPSHOT_AT, DojangAttesterIds.UPBIT_KOREA);
+    }
+
+    function test_getVerifiedBalance_revert_when_rootSchemaMismatch() public {
+        balanceRootAttestation.schema = BALANCE_DOJANG_SCHEMA_UID;
+        mockGetBalanceAttestation(balanceAttestation);
+        mockRootAttestationByRefUID(balanceRootAttestation);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AttestationVerifier.MisMatchSchema.selector, BALANCE_DOJANG_SCHEMA_UID, BALANCE_ROOT_DOJANG_SCHEMA_UID
+            )
+        );
+        dojangScroll.getVerifiedBalance(ADDRESS, SOLANA_COIN_TYPE, SNAPSHOT_AT, DojangAttesterIds.UPBIT_KOREA);
+    }
+
+    function test_getVerifiedBalance_revert_when_rootAttesterMismatch() public {
+        address malicious = makeAddr("malicious");
+        balanceRootAttestation.attester = malicious;
+        mockGetBalanceAttestation(balanceAttestation);
+        mockRootAttestationByRefUID(balanceRootAttestation);
+
+        vm.expectRevert(abi.encodeWithSelector(IDojangScroll.MismatchRootAttester.selector, malicious, attester));
+        dojangScroll.getVerifiedBalance(ADDRESS, SOLANA_COIN_TYPE, SNAPSHOT_AT, DojangAttesterIds.UPBIT_KOREA);
+    }
+
     function test_getVerifiedBalance_succeeds() public {
         mockGetBalanceAttestation(balanceAttestation);
-        mockGetBalanceRootAttestation(balanceRootAttestation);
+        mockRootAttestationByRefUID(balanceRootAttestation);
 
         uint256 balance =
             dojangScroll.getVerifiedBalance(ADDRESS, SOLANA_COIN_TYPE, SNAPSHOT_AT, DojangAttesterIds.UPBIT_KOREA);


### PR DESCRIPTION
## What

`DojangScroll.getVerifiedBalance` now resolves the balance root attestation **directly from `attestation.refUID`** rather than re-deriving it through `_getBalanceRootAttestation`.

## Changes

- 🔒 Resolve the root via `_EAS.getAttestation(attestation.refUID)` and verify it against the `BALANCE_ROOT_DOJANG` schema (recipient `address(0)`).
- 🚧 Revert with `NotVerifiedBalance` when `refUID == 0`.
- ✨ Add `MismatchRootAttester(address actual, address expected)` and enforce that the root's attester matches the expected attester for the given attester id.
- 🔥 Drop the now-redundant `rootAttestation.uid != attestation.refUID` check.
- 🔖 Bump `DojangScroll` semver `0.5.0` → `0.5.1`.
- ✅ Add tests for the zero-refUID, root-schema-mismatch, and root-attester-mismatch paths; switch existing tests to the refUID-based mock.

## Scope

Contract + test changes only. On-chain upgrade and deployment artifacts (broadcast / deployments / README addresses) are handled separately.

Closes #34