### PR TITLE
feat(dojang): expose raw attestation getters on DojangScroll for ERC-4337 compatibility

### DIFF
--- a/src/DojangScroll.sol
+++ b/src/DojangScroll.sol
@@ -222,6 +222,66 @@ contract DojangScroll is UUPSUpgradeable, AccessControlUpgradeable, IDojangScrol
     }
 
     /**
+     * @inheritdoc IDojangScroll
+     */
+    function getAddressAttestation(
+        address addr,
+        DojangAttesterId attesterId
+    )
+        external
+        view
+        returns (Attestation memory)
+    {
+        return _getAddressAttestation(addr, attesterId);
+    }
+
+    /**
+     * @inheritdoc IDojangScroll
+     */
+    function getBalanceRootAttestation(
+        uint256 coinType,
+        uint64 snapshotAt,
+        DojangAttesterId attesterId
+    )
+        external
+        view
+        returns (Attestation memory)
+    {
+        return _getBalanceRootAttestation(coinType, snapshotAt, attesterId);
+    }
+
+    /**
+     * @inheritdoc IDojangScroll
+     */
+    function getBalanceAttestation(
+        address recipient,
+        uint256 coinType,
+        uint64 snapshotAt,
+        DojangAttesterId attesterId
+    )
+        external
+        view
+        returns (Attestation memory)
+    {
+        return _getBalanceAttestation(recipient, coinType, snapshotAt, attesterId);
+    }
+
+    /**
+     * @inheritdoc IDojangScroll
+     */
+    function getVerifyCodeAttestation(
+        bytes32 codeHash,
+        string calldata domain,
+        DojangAttesterId attesterId
+    )
+        external
+        view
+        returns (Attestation memory)
+    {
+        return _getVerifyCodeAttestation(codeHash, domain, attesterId);
+    }
+
+    /**
      * @dev Initializes the contract
      * @param admin The address to be granted with the default admin Role
      */

--- a/src/interfaces/IDojangScroll.sol
+++ b/src/interfaces/IDojangScroll.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {DojangAttesterId} from "../libraries/Types.sol";
+import {Attestation} from "@eas-contracts/contracts/IEAS.sol";
 
 interface IDojangScroll {
     /**
@@ -139,4 +140,68 @@ interface IDojangScroll {
         external
         view
         returns (bytes32);
+
+    /**
+     * @notice Returns the address attestation record for the given user address and attester
+     * @dev Returns the raw attestation without evaluating timestamps or reverting on expiration,
+     *      enabling ERC-4337 validation (where TIMESTAMP opcode is banned under ERC-7562)
+     *      to extract expirationTime as validUntil.
+     * @param addr The address of the user
+     * @param attesterId The attester identifier
+     * @return The address attestation record
+     */
+    function getAddressAttestation(address addr, DojangAttesterId attesterId) external view returns (Attestation memory);
+
+    /**
+     * @notice Returns the balance root attestation record for the given coin type and timestamp
+     * @dev Returns the raw attestation without evaluating timestamps or reverting on expiration.
+     * @param coinType The custom coin type of the asset
+     * @param snapshotAt The timestamp representing when the balance snapshot was taken
+     * @param attesterId The attester identifier
+     * @return The balance root attestation record
+     */
+    function getBalanceRootAttestation(
+        uint256 coinType,
+        uint64 snapshotAt,
+        DojangAttesterId attesterId
+    )
+        external
+        view
+        returns (Attestation memory);
+
+    /**
+     * @notice Returns the balance attestation record for the given recipient, coin type and timestamp
+     * @dev Returns the raw attestation without evaluating timestamps or reverting on expiration.
+     * @param recipient The address of the user
+     * @param coinType The custom coin type of the asset
+     * @param snapshotAt The timestamp representing when the balance snapshot was taken
+     * @param attesterId The attester identifier
+     * @return The balance attestation record
+     */
+    function getBalanceAttestation(
+        address recipient,
+        uint256 coinType,
+        uint64 snapshotAt,
+        DojangAttesterId attesterId
+    )
+        external
+        view
+        returns (Attestation memory);
+
+    /**
+     * @notice Returns the verify-code attestation record for the given codeHash and domain
+     * @dev Returns the raw attestation without evaluating timestamps or reverting on expiration.
+     * @param codeHash The hashed verification code
+     * @param domain The domain string associated with the verification code; should be canonicalized before lookup
+     * @param attesterId The attester identifier
+     * @return The verify-code attestation record
+     */
+    function getVerifyCodeAttestation(
+        bytes32 codeHash,
+        string calldata domain,
+        DojangAttesterId attesterId
+    )
+        external
+        view
+        returns (Attestation memory);
 }

--- a/test/DojangScroll.t.sol
+++ b/test/DojangScroll.t.sol
@@ -726,4 +726,41 @@ contract DojangScroll_Test is DojangScroll_Base {
             dojangScroll.getVerifyCodeAttestationUid(CODE_HASH, DOMAIN, DojangAttesterIds.UPBIT_KOREA);
         assertEq(attestationUid, VERIFY_CODE_ATTESTATION_UID);
     }
+
+    function test_getAddressAttestation_succeeds() public {
+        mockGetAddressAttestation(addressAttestation);
+
+        Attestation memory att = dojangScroll.getAddressAttestation(ADDRESS, DojangAttesterIds.UPBIT_KOREA);
+        assertEq(att.uid, ADDRESS_ATTESTATION_UID);
+        assertEq(att.recipient, ADDRESS);
+        assertEq(att.expirationTime, addressAttestation.expirationTime);
+    }
+
+    function test_getBalanceRootAttestation_succeeds() public {
+        mockGetBalanceRootAttestation(balanceRootAttestation);
+
+        Attestation memory att =
+            dojangScroll.getBalanceRootAttestation(SOLANA_COIN_TYPE, SNAPSHOT_AT, DojangAttesterIds.UPBIT_KOREA);
+        assertEq(att.uid, BALANCE_ROOT_ATTESTATION_UID);
+        assertEq(att.recipient, address(0));
+        assertEq(att.expirationTime, balanceRootAttestation.expirationTime);
+    }
+
+    function test_getBalanceAttestation_succeeds() public {
+        mockGetBalanceAttestation(balanceAttestation);
+
+        Attestation memory att =
+            dojangScroll.getBalanceAttestation(ADDRESS, SOLANA_COIN_TYPE, SNAPSHOT_AT, DojangAttesterIds.UPBIT_KOREA);
+        assertEq(att.uid, BALANCE_ATTESTATION_UID);
+        assertEq(att.recipient, ADDRESS);
+        assertEq(att.expirationTime, balanceAttestation.expirationTime);
+    }
+
+    function test_getVerifyCodeAttestation_succeeds() public {
+        mockGetVerifyCodeAttestation(verifyCodeAttestation);
+
+        Attestation memory att = dojangScroll.getVerifyCodeAttestation(CODE_HASH, DOMAIN, DojangAttesterIds.UPBIT_KOREA);
+        assertEq(att.uid, VERIFY_CODE_ATTESTATION_UID);
+        assertEq(att.expirationTime, verifyCodeAttestation.expirationTime);
+    }
 }


### PR DESCRIPTION
Closes #37

### Motivation & Context

In ERC-4337 (and under ERC-7562 opcode validation rules), executing `TIMESTAMP` inside `validateUserOp` or `validatePaymasterUserOp` is strictly banned. 

Currently, `DojangScroll.isVerified()` and `getVerified*AttestationUid()` evaluate expiration on-chain via `AttestationVerifier._verify()`, which reads `block.timestamp`. When an account abstraction contract or a paymaster (e.g. Dojang-gated gas sponsorship) invokes `isVerified()` during validation simulation, bundlers reject the UserOp with:
`eth_sendUserOperation: paymaster uses banned opcode: TIMESTAMP`

To support standard ERC-4337 validation patterns without requiring external contracts to bypass `DojangScroll` and reach directly into `EAS` and the indexer, this PR exposes un-evaluated attestation getters.

---

### Changes

1. **`IDojangScroll.sol`**:
   - Added interface declarations for:
     - `getAddressAttestation(address addr, DojangAttesterId attesterId)`
     - `getBalanceRootAttestation(uint256 coinType, uint64 snapshotAt, DojangAttesterId attesterId)`
     - `getBalanceAttestation(address recipient, uint256 coinType, uint64 snapshotAt, DojangAttesterId attesterId)`
     - `getVerifyCodeAttestation(bytes32 codeHash, string calldata domain, DojangAttesterId attesterId)`

2. **`DojangScroll.sol`**:
   - Implemented external views that return the raw `Attestation` memory struct resolved from the indexer and EAS without running `_verify()` or checking `block.timestamp`.
   - Allows AA wallets / paymasters to read `expirationTime` directly and forward it to EntryPoint as `validUntil` in `validationData`.

3. **`test/DojangScroll.t.sol`**:
   - Added unit test coverage verifying that raw getters return accurate `Attestation` structs across all schemas.

---

### Validation

- `forge test --ffi`: All 47 test suites (205 tests total) passed.
- `forge inspect DojangScroll storageLayout`: Confirmed zero storage layout modifications on upgradeable proxy.
- `forge fmt`: Code formatting validated.